### PR TITLE
Reopen timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@ It has many configurable options in which you can decide whether to close tabs b
 
 ---
 
+## Installation
+**note**: You must use node version `<= 16.13.0`. Otherwise you will encounter an error about `error:0308010C:digital envelope routines::unsupported`.
+To change your node version, check out [nvm](https://github.com/nvm-sh/nvm).
+
+
+1. Clone this repo `git clone https://github.com/AngeloKandah/DuplicateTabCloser.git` into a folder of your choice.
+2. Make sure you are in that folder in your cli.
+2. Install Dependencies `npm install`.
+3. Build the project `npm run build`.
+4. After this is installed, you will produce a /dist folder.
+5. Then go to chrome://extensions/ and click `load unpacked` and point it to that dist folder.
+
+---
+
 ## Options
 There are three options: moveTabs, effectTabGroups, effectWindows.
 There is also exclusions, which the user creates a list of so the extension knows to ignore urls that return true for the exclusion.
@@ -24,15 +38,3 @@ This option will detect duplicates across all tab groups, basically ignoring any
 ### Exclusions
 
 The exclusions allows for the user to be able to decide what they want the extension to ignore. The exclusions supports regex so you can have specific exclusions and the tabs that meet the criteria will be ignored from being closed if a duplicate is detected.
-
----
-
-## Installation
-
-
-1. Clone this repo `git clone https://github.com/AngeloKandah/DuplicateTabCloser.git` into a folder of your choice.
-2. Make sure you are in that folder in your cli.
-2. Install Dependencies `npm install`.
-3. Build the project `npm run build`.
-4. After this is installed, you will produce a /dist folder.
-5. Then go to chrome://extensions/ and click `load unpacked` and point it to that dist folder.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To change your node version, check out [nvm](https://github.com/nvm-sh/nvm).
 2. Make sure you are in that folder in your cli.
 2. Install Dependencies `npm install`.
 3. Build the project `npm run build`.
-4. After this is installed, you will produce a /dist folder.
+4. After this is installed, you will produce a `/dist` folder.
 5. Then go to chrome://extensions/ and click `load unpacked` and point it to that dist folder.
 
 ---

--- a/src/background.js
+++ b/src/background.js
@@ -67,7 +67,6 @@ export const cleanupRecentlyClosedTabs = () => {
 }
 
 // https://stackoverflow.com/questions/9229645/remove-duplicate-values-from-js-array
-// "First or last?"
 function uniqByKeepLast(a, key) {
     return [
         ...new Map(

--- a/src/background.js
+++ b/src/background.js
@@ -21,7 +21,6 @@ function initExtension() {
 }
 
 // https://stackoverflow.com/questions/14368596/how-can-i-check-that-two-objects-have-the-same-set-of-property-names
-// second answer ES6 variadic version
 function objectsHaveSameKeys(...objects) {
     const allKeys = objects.reduce((keys, object) => keys.concat(Object.keys(object)), []);
     const union = new Set(allKeys);

--- a/src/background.js
+++ b/src/background.js
@@ -167,11 +167,6 @@ async function onUpdate(
     { url: loading, status },
     { url, openerTabId, windowId, groupId }
 ) {
-    // console.log('onupdate start')
-    // console.log({ tabId });
-    // console.log({ changeInfo: { loading, status } });
-    // console.log({ tab: { url, openerTabId, windowId, groupId } });
-    // console.log('onupdate end')
 
     if (loading || status === 'unloaded') return;
 

--- a/src/options.html
+++ b/src/options.html
@@ -29,6 +29,12 @@
                     <span>Detect duplicates between tab groups</span>
                 </label>
             </div>
+            <div class="option">
+                <label class="optionList">
+                    <span>Grace period to reopen a closed tab (in seconds)</span>
+                    <input type="number" id="closeGracePeriod">
+                </label>
+            </div>
         </div>
         <div class="optionPage" id="exclusionPage">
             <h1>Exclusions</h1>

--- a/src/options.js
+++ b/src/options.js
@@ -1,5 +1,5 @@
 import './styles.css';
-import { getLocalStorageKey, updateOptions } from './chrome_storage.js';
+import { updateOptions } from './chrome_storage.js';
 import { getOptions } from './background.js';
 
 //any jquery-ers in the chat?

--- a/src/options.js
+++ b/src/options.js
@@ -1,7 +1,11 @@
 import './styles.css';
 import { getLocalStorageKey, updateOptions } from './chrome_storage.js';
+import { getOptions } from './background.js';
 
-getLocalStorageKey('options').then(({ options }) => {
+//any jquery-ers in the chat?
+const $ = id => document.getElementById(id);
+
+getOptions().then(options => {
     const {
         moveTabs,
         effectWindows,
@@ -9,11 +13,14 @@ getLocalStorageKey('options').then(({ options }) => {
         exclusions,
         logMaxUrls,
         loggedUrls,
+        closeGracePeriod,
     } = options;
-    document.getElementById('moveTabs').checked = moveTabs;
-    document.getElementById('effectWindows').checked = effectWindows;
-    document.getElementById('effectTabGroups').checked = effectTabGroups;
-    document.getElementById('logMaxUrls').value = logMaxUrls;
+    $('moveTabs').checked = moveTabs;
+    $('effectWindows').checked = effectWindows;
+    $('effectTabGroups').checked = effectTabGroups;
+    $('logMaxUrls').value = logMaxUrls;
+    $('closeGracePeriod').value = closeGracePeriod;
+
     createExclusionList(exclusions);
     createLogList(loggedUrls);
 });
@@ -22,8 +29,8 @@ document.querySelectorAll('.optionList').forEach((item) => {
     item.addEventListener('click', submitChanges);
 });
 
-const exclusionBox = document.getElementById('exclusionArray');
-const exclusionList = document.getElementById('exclusions');
+const exclusionBox = $('exclusionArray');
+const exclusionList = $('exclusions');
 
 function createExclusionList(exclusions) {
     exclusions.forEach(addToExclusionList);
@@ -59,14 +66,13 @@ function createDeleteButton() {
     return deleteButton;
 }
 
-function isOptionEnabled(id) {
-    return document.getElementById(id).checked;
+function isChecked(id) {
+    return $(id).checked;
 }
 
 async function submitChanges() {
     const settingFields = ['moveTabs', 'effectWindows', 'effectTabGroups'];
-    const [moveTabs, effectWindows, effectTabGroups] =
-        settingFields.map(isOptionEnabled);
+    const [moveTabs, effectWindows, effectTabGroups] = settingFields.map(isChecked);
     await updateOptions({ moveTabs, effectWindows, effectTabGroups });
 }
 
@@ -89,7 +95,7 @@ exclusionBox.addEventListener('keyup', async ({ code }) => {
     addToExclusionList(newExclusion);
 });
 
-const pages = [...document.getElementById('pageContainer').children];
+const pages = [...$('pageContainer').children];
 
 function setPage(goingForward) {
     const currentPageIndex = pages.findIndex((page) =>
@@ -106,11 +112,11 @@ function setPage(goingForward) {
 const nextPage = () => setPage(true);
 const prevPage = () => setPage(false);
 
-document.getElementById('nextPage').addEventListener('click', nextPage);
-document.getElementById('previousPage').addEventListener('click', prevPage);
+$('nextPage').addEventListener('click', nextPage);
+$('previousPage').addEventListener('click', prevPage);
 
-const numberOfUrlsToLog = document.getElementById('logMaxUrls');
-const loggedList = document.getElementById('loggedUrls');
+const numberOfUrlsToLog = $('logMaxUrls');
+const loggedList = $('loggedUrls');
 
 logMaxUrls.addEventListener('keyup', async ({ code }) => {
     const { value: newNumber } = numberOfUrlsToLog;
@@ -118,6 +124,15 @@ logMaxUrls.addEventListener('keyup', async ({ code }) => {
         return;
     }
     updateOptions({ logMaxUrls: newNumber });
+});
+
+const gracePeriodInput = $('closeGracePeriod');
+
+gracePeriodInput.addEventListener('change', async (event) => {
+    const { target: { value: closeGracePeriodRaw } } = event;
+    const closeGracePeriod = parseInt(closeGracePeriodRaw, 10);
+    console.log(`updating grace period to ${closeGracePeriod}`);
+    updateOptions({ closeGracePeriod });
 });
 
 function createLogList(urls) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -96,7 +96,7 @@ input::-webkit-inner-spin-button {
 }
 
 input[type='number'] {
-    width: 15px;
+    width: 2em;
 }
 
 input[type='text'] {


### PR DESCRIPTION
supports new option to reopen a closed tab within a grace period defined in settings page (in seconds). Default is 5 seconds.

added graceful addition of options where previously options had to be erased and lost in order to add new ones. 

added funny `$`

moved installation to the top (where it should be imo)

going to move the global array later to use storage api. Want to support more than the options namespace before using more localstorage ish. 

I made something use an `em` unit. Doesn't look particularly beautiful, but try to avoid any px units. Hardcoding CSS like that === bad.